### PR TITLE
fix: update package.json scripts to match current CLI commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "build": "bun build src/cli.ts --target=node --outfile=dist/cli.js && bun run build:types && cp -r src/templates dist/ && chmod +x ./dist/cli.js",
     "build:types": "tsc --emitDeclarationOnly",
     "init": "bun run src/cli.ts init",
-    "compile": "bun run src/cli.ts compile",
-    "preview": "bun run src/cli.ts preview",
+    "sync": "bun run src/cli.ts sync",
+    "plan": "bun run src/cli.ts plan",
     "prepublishOnly": "bun run build",
     "test": "bun test",
     "typecheck": "tsc --noEmit"

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -2,10 +2,10 @@ import { DEFAULT_AI_DOCS_DIR, DEFAULT_RULES_DIR } from '../constants';
 
 export const showHelp = (): void => {
   console.log(`
-ai-doc-sync
+ai-docs-sync
 
 Usage:
-  npx ai-doc-sync [command]
+  npx ai-docs-sync [command]
 
 Commands:
   (default)  - Sync rules from ${DEFAULT_AI_DOCS_DIR}/${DEFAULT_RULES_DIR} to output files
@@ -14,8 +14,8 @@ Commands:
   help       - Show this help message
 
 Examples:
-  npx ai-doc-sync       # Sync rules (default behavior)
-  npx ai-doc-sync plan  # Preview changes without writing
-  npx ai-doc-sync init  # Initialize a new project
+  npx ai-docs-sync       # Sync rules (default behavior)
+  npx ai-docs-sync plan  # Preview changes without writing
+  npx ai-docs-sync init  # Initialize a new project
   `);
 };

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -35,6 +35,6 @@ export const initProject = (): void => {
   console.log('Next steps:');
   console.log(`1. Edit rules: modify files in the ${DEFAULT_AI_DOCS_DIR}/${DEFAULT_RULES_DIR}/ directory`);
   console.log(`2. Edit ignore patterns: modify the ${DEFAULT_AI_DOCS_DIR}/ignore file`);
-  console.log('3. Compile: npx ai-docs-cli compile');
-  console.log('4. Preview: npx ai-docs-cli preview');
+  console.log('3. Sync: ai-docs-sync');
+  console.log('4. Preview: ai-docs-sync plan');
 };


### PR DESCRIPTION
## Summary
- Updated npm scripts in package.json to align with current CLI command names
- Renamed `compile` → `sync` 
- Renamed `preview` → `plan`

## Context
The package.json scripts were using outdated command names (`compile` and `preview`) that don't match the actual CLI commands documented in CLAUDE.md (`sync` and `plan`).

## Test plan
- [ ] Run `npm run sync` to verify the sync command works
- [ ] Run `npm run plan` to verify the plan command works
- [ ] Run `npm run build` to ensure the build still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)